### PR TITLE
fixed get users api not sending response back

### DIFF
--- a/routes/users-router.js
+++ b/routes/users-router.js
@@ -25,7 +25,7 @@ router.get("/:id", async (req, res) => {
       res.status(200).json(user);
     }
   } catch (err) {
-    res.status({ err: "The user information could not be retrieved" });
+    res.status(500).json({ err: "The user information could not be retrieved" });
   }
 });
 


### PR DESCRIPTION
GET users api on error is not setting status 500 and causes the request to remain pending on client side.